### PR TITLE
update: fix missing md5 info;

### DIFF
--- a/dist/mainnet-geth-pbss-20250520-pruneancient.csv
+++ b/dist/mainnet-geth-pbss-20250520-pruneancient.csv
@@ -1,3 +1,3 @@
 filename,URL,md5,size
-mainnet-geth-pbss-base-49987579.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-base-49987579.tar.lz4,,992.09GB
+mainnet-geth-pbss-base-49987579.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-base-49987579.tar.lz4,d65d64c65ba3de4050c42114ca3b8df0,992.09GB
 mainnet-geth-pbss-blocks-pruneancient-49897579.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-pruneancient-49897579.tar.lz4,59a0f9a36fa6c7c49dde9e50d3e9ecde,0.00GB


### PR DESCRIPTION
This PR will fix a missing md5 issue.

Currently, an error will be reported when downloading mainnet-geth-pbss-20250520-pruneancient and enabling md5 checking.


| Snapshot Type   | Snapshot File                                                                               | Total Size | Remark        |
|-----------------|---------------------------------------------------------------------------------------------|------------|---------------|
| Pruned Snapshot | [mainnet-geth-pbss-20250520-pruneancient] | **~900GB** | BSC >= v1.5.5 |