### PR TITLE
update: mainnet snapshot 2026/08/05

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Usage: [usage/legacyfullnode_usage.md](./usage/legacyfullnode_usage.md)
 
 | Snapshot Type   | Snapshot File                                                                               | Total Size | Remark        |
 |-----------------|---------------------------------------------------------------------------------------------|------------|---------------|
-| Full Snapshot   | [mainnet-geth-pbss-20260525](dist/mainnet-geth-pbss-20260525.csv)                           | **~6.0TB** | BSC >= v1.7.2 |
-| Pruned Snapshot | [mainnet-geth-pbss-20260525-pruneancient](dist/mainnet-geth-pbss-20260525-pruneancient.csv) | **~1.6TB** | BSC >= v1.7.2 |
+| Full Snapshot   | [mainnet-geth-pbss-20260805](dist/mainnet-geth-pbss-20260805.csv)                           | **~6.6TB** | BSC >= v1.7.2 |
+| Pruned Snapshot | [mainnet-geth-pbss-20260805-pruneancient](dist/mainnet-geth-pbss-20260805-pruneancient.csv) | **~1.7TB** | BSC >= v1.7.2 |
 
 ### testnet(update every 4 months)
 
@@ -43,11 +43,11 @@ wget https://raw.githubusercontent.com/bnb-chain/bsc-snapshots/main/dist/fetch-s
 **Quick start (download, verify, extract, auto-delete in one step):**
 
 ```bash
-# full snapshot (~6.0TB, needs at least 7TB free, or 6TB with --auto-delete)
-bash fetch-snapshot.sh -d -e -c --auto-delete -D /data/snapshot -E /data/bsc mainnet-geth-pbss-20260525
+# full snapshot (~6.6TB, needs at least 8TB free, or 7TB with --auto-delete)
+bash fetch-snapshot.sh -d -e -c --auto-delete -D /data/snapshot -E /data/bsc mainnet-geth-pbss-20260805
 
-# pruned snapshot (~1.6TB, needs at least 2TB free with --auto-delete)
-bash fetch-snapshot.sh -d -e -c -p --auto-delete -D /data/snapshot -E /data/bsc mainnet-geth-pbss-20260525
+# pruned snapshot (~1.7TB, needs at least 2TB free with --auto-delete)
+bash fetch-snapshot.sh -d -e -c -p --auto-delete -D /data/snapshot -E /data/bsc mainnet-geth-pbss-20260805
 ```
 
 After extraction, files will be at `/data/bsc/geth/chaindata/...`, start geth with `--datadir /data/bsc`.
@@ -56,10 +56,10 @@ After extraction, files will be at `/data/bsc/geth/chaindata/...`, start geth wi
 
 ```bash
 # step 1: download & checksum
-bash fetch-snapshot.sh -d -c -D /data/snapshot mainnet-geth-pbss-20260525
+bash fetch-snapshot.sh -d -c -D /data/snapshot mainnet-geth-pbss-20260805
 
 # step 2: extract to datadir
-bash fetch-snapshot.sh -e -D /data/snapshot -E /data/bsc mainnet-geth-pbss-20260525
+bash fetch-snapshot.sh -e -D /data/snapshot -E /data/bsc mainnet-geth-pbss-20260805
 ```
 
 You can remove the `-c` option to skip MD5 checking. Run `bash fetch-snapshot.sh --help` for all options.
@@ -69,6 +69,7 @@ You can remove the `-c` option to skip MD5 checking. Run `bash fetch-snapshot.sh
 ### Previous snapshot
 
 - **mainnet**:
+  - [mainnet-geth-pbss-20260525](dist/mainnet-geth-pbss-20260525.csv), [mainnet-geth-pbss-20260525-pruneancient](dist/mainnet-geth-pbss-20260525-pruneancient.csv)
   - [mainnet-geth-pbss-20260408](dist/mainnet-geth-pbss-20260408.csv), [mainnet-geth-pbss-20260408-pruneancient](dist/mainnet-geth-pbss-20260408-pruneancient.csv)
   - [mainnet-geth-pbss-20260306](dist/mainnet-geth-pbss-20260306.csv), [mainnet-geth-pbss-20260306-pruneancient](dist/mainnet-geth-pbss-20260306-pruneancient.csv)
   - [mainnet-geth-pbss-20260202](dist/mainnet-geth-pbss-20260202.csv), [mainnet-geth-pbss-20260202-pruneancient](dist/mainnet-geth-pbss-20260202-pruneancient.csv)

--- a/dist/mainnet-geth-pbss-20260805-pruneancient.csv
+++ b/dist/mainnet-geth-pbss-20260805-pruneancient.csv
@@ -1,0 +1,3 @@
+filename,URL,md5,size
+mainnet-geth-pbss-base-113615622.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-base-113615622.tar.lz4,cbff02999c07428dc75480fc2f49517d,1742.48GB
+mainnet-geth-pbss-blocks-pruneancient-113525622.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-pruneancient-113525622.tar.lz4,8cacfd842b59ce6b7f21b53ba3db604b,0.00GB

--- a/dist/mainnet-geth-pbss-20260805.csv
+++ b/dist/mainnet-geth-pbss-20260805.csv
@@ -1,0 +1,13 @@
+filename,URL,md5,size
+mainnet-geth-pbss-base-113615622.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-base-113615622.tar.lz4,cbff02999c07428dc75480fc2f49517d,1742.48GB
+mainnet-geth-pbss-blocks-52560000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-52560000.tar.lz4,1a3a7f11ab30d6b0b34da2e733ac7d83,647.96GB
+mainnet-geth-pbss-blocks-73584000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-73584000.tar.lz4,53f4dc7bf4b6fcbb6cf5a6ea984863f0,639.74GB
+mainnet-geth-pbss-blocks-21024000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-21024000.tar.lz4,ef20506070cbe2deb3b0c3c5cae3149d,601.39GB
+mainnet-geth-pbss-blocks-42048000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-42048000.tar.lz4,6a21f55892f6da5f6ca5b77f6c0d88bd,532.23GB
+mainnet-geth-pbss-blocks-63072000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-63072000.tar.lz4,7db29b132f6e45f9f52f07381fdac9b3,445.25GB
+mainnet-geth-pbss-blocks-31536000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-31536000.tar.lz4,7ed223135e0bb50fdcf625529d89b83c,376.89GB
+mainnet-geth-pbss-blocks-84096000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-84096000.tar.lz4,5a324afc3a4b24ee2a16b44475e3d191,376.58GB
+mainnet-geth-pbss-blocks-105120000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-105120000.tar.lz4,ab4805de4b89b36ad7ac4ee8f3d7106b,334.20GB
+mainnet-geth-pbss-blocks-94608000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-94608000.tar.lz4,c92a8e4d799699ab26483e4fe2bfafed,324.64GB
+mainnet-geth-pbss-blocks-113525622.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-113525622.tar.lz4,888111cf6fff9bc99bf78ad4805a1c39,307.73GB
+mainnet-geth-pbss-blocks-10512000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-10512000.tar.lz4,3a973854371e526be8dbbce63aad855b,289.91GB


### PR DESCRIPTION
Add the 2026/08/05 mainnet legacy-fullnode snapshot.

- `dist/mainnet-geth-pbss-20260805.csv` — full snapshot, 12 files, 6619.00GB total (~6.6TB). Base block 113615622, head blocks 113525622, plus the new `blocks-105120000` year chunk.
- `dist/mainnet-geth-pbss-20260805-pruneancient.csv` — pruned snapshot, ~1.7TB.
- `README.md` — point the mainnet table and the `fetch-snapshot.sh` examples at 20260805, bump the free-space hints (8TB free / 7TB with `--auto-delete`), and move 20260525 into the previous-snapshot list.

Checks done:

- base filename + md5 match between the full and pruneancient CSVs.
- Year chunks 10512000 → 105120000 are continuous, no gap, plus the head chunk.
- `HEAD` request against all four new URLs returns 200 and the `content-length` matches the size column (base 1742.47GB, head blocks 307.72GB, 105120000 334.19GB).
- The `0.00GB` pruneancient blocks entry is the freezer index tarball (602 bytes), same as in 20260525 / 20260408.
- Both CSVs end with a trailing newline so `fetch-snapshot.sh` does not drop the last row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)